### PR TITLE
Feature/non ssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can now access your caliopen instance with your web browser on localhost:808
 ## Load demo fixtures data
 
 ```
-ansible-playbook -i hosts -K playbook-load-data.yml
+ansible-playbook -i hosts playbook-load-data.yml
 ```
 
 It will create a dev user with 123456 as password and load some messages

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ For deployment on Gandi's server, please modify the hosts file and add your valu
 - ansible_ssh_host=
 - ansible_ssh_private_key_file= (Only if your authentification on Gandi's server is with SSH key. If not, you can remove the ansible_ssh_private_key_file method)
 
+### To deploy using HTTPS only
+
+If you have a TLS certificate and the related private key, you can set `use_https` variable to true in the hosts file
+and place the related crt and key files inside roles/caliopen/file directory using file name: caliopen.crt and caliopen.key
+
 
 You can now deploy the docker's stack on a machine
 

--- a/hosts
+++ b/hosts
@@ -1,5 +1,6 @@
 [caliopen:vars]
 use_https=false
+vhost_name=poc.caliopen.org
 
 [caliopen]
 docker-stack ansible_ssh_host= ansible_ssh_user=root ansible_ssh_private_key_file=

--- a/hosts
+++ b/hosts
@@ -1,3 +1,6 @@
+[caliopen:vars]
+use_https=false
+
 [caliopen]
 docker-stack ansible_ssh_host= ansible_ssh_user=root ansible_ssh_private_key_file=
 [postfix]

--- a/roles/caliopen/tasks/main.yaml
+++ b/roles/caliopen/tasks/main.yaml
@@ -48,7 +48,7 @@
   template: src=nginx.j2 dest=/etc/nginx/sites-enabled/poc
   notify:
       - restart nginx
-  when: not use_https
+  when: use_https == 'false'
 
 - name: install docker
   shell: curl -sSL https://get.docker.com/ | sh

--- a/roles/caliopen/tasks/main.yaml
+++ b/roles/caliopen/tasks/main.yaml
@@ -36,11 +36,19 @@
   with_items:
     - caliopen.crt
     - caliopen.key
+  when: use_https
 
-- name: configure nginx
+- name: configure nginx using https
+  template: src=nginx_https.j2 dest=/etc/nginx/sites-enabled/poc
+  notify:
+      - restart nginx
+  when: use_https
+
+- name: configure nginx only http
   template: src=nginx.j2 dest=/etc/nginx/sites-enabled/poc
   notify:
       - restart nginx
+  when: not use_https
 
 - name: install docker
   shell: curl -sSL https://get.docker.com/ | sh

--- a/roles/caliopen/templates/nginx.j2
+++ b/roles/caliopen/templates/nginx.j2
@@ -6,7 +6,7 @@ upstream nodeapp {
 server {
     listen 		80,
     listen              [::]:80;
-    server_name         poc.caliopen.org;
+    server_name         {{ vhost_name }};
 
     location / {
         proxy_http_version 1.1;

--- a/roles/caliopen/templates/nginx.j2
+++ b/roles/caliopen/templates/nginx.j2
@@ -4,7 +4,7 @@ upstream nodeapp {
 }
 
 server {
-    listen 		80,
+    listen 		80;
     listen              [::]:80;
     server_name         {{ vhost_name }};
 

--- a/roles/caliopen/templates/nginx.j2
+++ b/roles/caliopen/templates/nginx.j2
@@ -4,15 +4,9 @@ upstream nodeapp {
 }
 
 server {
-    listen 		443 ssl;
-    listen              [::]:443 ssl;
+    listen 		80,
+    listen              [::]:80;
     server_name         poc.caliopen.org;
-
-    ssl_certificate     /etc/nginx/certs/caliopen.crt;
-    ssl_certificate_key /etc/nginx/certs/caliopen.key;
-    ssl_prefer_server_ciphers On;
-    ssl_protocols TLSv1.1 TLSv1.2;
-    ssl_ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS;
 
     location / {
         proxy_http_version 1.1;
@@ -24,11 +18,3 @@ server {
         proxy_redirect off;
     }
 }
-
-server {
-    listen 80;
-    listen [::]:80;
-    server_name poc.caliopen.org;
-    rewrite     ^(.*)   https://$server_name$1 permanent;
-}
-

--- a/roles/caliopen/templates/nginx_https.j2
+++ b/roles/caliopen/templates/nginx_https.j2
@@ -1,0 +1,34 @@
+upstream nodeapp {
+  server 0.0.0.0:4000;
+  keepalive 8;
+}
+
+server {
+    listen 		443 ssl;
+    listen              [::]:443 ssl;
+    server_name         poc.caliopen.org;
+
+    ssl_certificate     /etc/nginx/certs/caliopen.crt;
+    ssl_certificate_key /etc/nginx/certs/caliopen.key;
+    ssl_prefer_server_ciphers On;
+    ssl_protocols TLSv1.1 TLSv1.2;
+    ssl_ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS;
+
+    location / {
+        proxy_http_version 1.1;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-NginX-Proxy true;
+        proxy_pass http://nodeapp;
+        proxy_redirect off;
+    }
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name poc.caliopen.org;
+    rewrite     ^(.*)   https://$server_name$1 permanent;
+}
+

--- a/roles/caliopen/templates/nginx_https.j2
+++ b/roles/caliopen/templates/nginx_https.j2
@@ -6,7 +6,7 @@ upstream nodeapp {
 server {
     listen 		443 ssl;
     listen              [::]:443 ssl;
-    server_name         poc.caliopen.org;
+    server_name         {{ vhost_name }};
 
     ssl_certificate     /etc/nginx/certs/caliopen.crt;
     ssl_certificate_key /etc/nginx/certs/caliopen.key;
@@ -28,7 +28,7 @@ server {
 server {
     listen 80;
     listen [::]:80;
-    server_name poc.caliopen.org;
+    server_name {{ vhost_name }};
     rewrite     ^(.*)   https://$server_name$1 permanent;
 }
 


### PR DESCRIPTION
Permit to deploy a caliopen stack using docker-compose and using nginx without HTTPS